### PR TITLE
fix(depcruiser): update config resolver

### DIFF
--- a/packages/depcruiser/src/api/config/resolver/resolver.test.ts
+++ b/packages/depcruiser/src/api/config/resolver/resolver.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { InputConfig } from '../../../config/index.ts';
 import type { BaseConfig } from '../defaults.ts';
 
+import { defaultConfig } from '../defaults.ts';
 import { loadConfig } from '../loader.ts';
 import * as resolve from './resolver.ts';
 
@@ -18,7 +19,6 @@ vi.mock('../defaults.ts', async (importActual) => {
     }
   });
 });
-import { defaultConfig } from '../defaults.ts';
 const mockLoadConfig = vi.mocked(loadConfig);
 
 describe('extends', () => {

--- a/packages/depcruiser/src/api/config/resolver/resolver.ts
+++ b/packages/depcruiser/src/api/config/resolver/resolver.ts
@@ -81,7 +81,7 @@ export const config = async ({
 
   // Start from default + input
   let merged = Obj.merge(defaultConfig, _input, {
-    array: { behavior: 'append' }
+    array: { behavior: 'overwrite' }
   }) as BaseConfig;
 
   // Resolve all extends recursively

--- a/packages/depcruiser/src/cli/command/depcruiser.ts
+++ b/packages/depcruiser/src/cli/command/depcruiser.ts
@@ -25,9 +25,7 @@ export class DependencyCruiser extends BaseCommand {
     scan: Args.string({
       name: 'filesOrDirectories',
       description:
-        'Files, directories, or glob patterns to analyze. Wrap globs in quotes to prevent shell expansion (e.g. "packages/**/src/**").',
-      required: false,
-      default: '.'
+        'Files, directories, or glob patterns to analyze. Wrap globs in quotes to prevent shell expansion (e.g. "packages/**/src/**").'
     })
   };
 
@@ -216,13 +214,17 @@ export default cfg;
 
   public async run(): Promise<void> {
     const { args, flags: _flags } = await this.parse(DependencyCruiser);
+    if (!args.scan && !_flags.init) {
+      await DependencyCruiser.run(['--help']);
+      return;
+    }
     if (_flags.init) {
       const runNow = await this.initConfig();
-      if (!runNow) return;
+      if (!runNow || !args.scan) return;
       this.cache.clear();
     }
     const cfg = await this.cache.get();
-    const { output: out, result } = await cruise([args.scan], {
+    const { output: out, result } = await cruise([args.scan!], {
       input: cfg,
       flags: _flags
     });

--- a/packages/tseslint/src/base/configs/root/rules.ts
+++ b/packages/tseslint/src/base/configs/root/rules.ts
@@ -197,7 +197,9 @@ export const typescriptEslint: ConfigWithExtends['rules'] = {
    * Disable ESLint's no-shadow to enable
    * TSESlint's extended version `@typescript-eslint/no-shadow`
    */
-  'no-shadow': 'off'
+  'no-shadow': 'off',
+
+  '@typescript-eslint/no-non-null-assertion': 'off'
 } as const;
 export const docs: ConfigWithExtends['rules'] = {
   /** tsdoc syntax errors are not significant and/or mature enough to require immediate attention */


### PR DESCRIPTION
- Input objects now overwrite default arrays instead of appending to them.
- CLI now runs help if no arg and not init flag are provided.

- Added rule to allow non-null assertions